### PR TITLE
Swap hard coded Uri for Uri generated by CreateWunUri method

### DIFF
--- a/WundergroundNetLib/UriProvider.cs
+++ b/WundergroundNetLib/UriProvider.cs
@@ -11,7 +11,7 @@ namespace WundergroundNetLib
     /// <summary>
     /// You will need to create your own Wunderground API key. 
     /// Learn more: http://www.wunderground.com/weather/api/d/docs 
-    /// Add that key to a file called WundergroundApiKey.txt
+    /// Add that key to a file called WundergroundApiKey.txt inside the folder called keys.
     /// Resources.WundergroundApiKey references the internal resource for that key
     /// </summary>
     public class UriProvider

--- a/WundergroundNetTest/DownloadJsonStringTest.cs
+++ b/WundergroundNetTest/DownloadJsonStringTest.cs
@@ -13,7 +13,8 @@ namespace WundergroundNetTest
             // Arrange
             bool actualResultValue = false;
             bool expectedResultValue = true;
-            Uri testUri = new Uri("http://api.wunderground.com/api/eaeb092839bd9885/pws/astronomy/q/pws:INORTHLA43.json");
+            UriProvider uriProvider = new UriProvider();
+            Uri testUri = uriProvider.CreateWunUri(WunDataFeatures.astronomy, "INORTHLA43");
             JsonProvider jsonProvider = new JsonProvider();
 
             //Act
@@ -28,10 +29,9 @@ namespace WundergroundNetTest
                 actualResultValue = true;
                 Console.WriteLine("false");
             }
-            
+
             //Assert
             Assert.AreEqual(expectedResultValue, actualResultValue);
-
         }
     }
 }


### PR DESCRIPTION
This hides the developer's private Wunderground key from public view.

New API keys can be generated here: http://www.wunderground.com/weather/api/d/xxxxxxxxxxxxxxx/edit.html 
